### PR TITLE
Fix the missing return type issue in generated Swift action

### DIFF
--- a/lib/fastlane/plugin/jira_release_notes/actions/jira_release_notes_action.rb
+++ b/lib/fastlane/plugin/jira_release_notes/actions/jira_release_notes_action.rb
@@ -69,6 +69,10 @@ module Fastlane
         "List of issues from jira. Formatted string or class"
       end
 
+      def self.return_type
+        :string
+      end
+
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :url,


### PR DESCRIPTION
Fixed #7 

Here is the generated Swift action:
```
/**
 Jira release notes

 - parameters:
   - url: URL for Jira instance
   - username: Username for Jira instance
   - password: Password or api token for Jira
   - project: Jira project name
   - status: Jira issue status
   - version: Jira project version
   - format: Format text. Plain, html or none
   - maxResults: Maximum number of issues

 - returns: List of issues from jira. Formatted string or class

 Fetch release notes for Jira project for version
*/
@discardableResult public func jiraReleaseNotes(url: String,
                                                username: String,
                                                password: String,
                                                project: String,
                                                status: String,
                                                version: Any,
                                                format: String,
                                                maxResults: String = "50") -> String {
let urlArg = RubyCommand.Argument(name: "url", value: url, type: nil)
let usernameArg = RubyCommand.Argument(name: "username", value: username, type: nil)
let passwordArg = RubyCommand.Argument(name: "password", value: password, type: nil)
let projectArg = RubyCommand.Argument(name: "project", value: project, type: nil)
let statusArg = RubyCommand.Argument(name: "status", value: status, type: nil)
let versionArg = RubyCommand.Argument(name: "version", value: version, type: nil)
let formatArg = RubyCommand.Argument(name: "format", value: format, type: nil)
let maxResultsArg = RubyCommand.Argument(name: "max_results", value: maxResults, type: nil)
let array: [RubyCommand.Argument?] = [urlArg,
usernameArg,
passwordArg,
projectArg,
statusArg,
versionArg,
formatArg,
maxResultsArg]
let args: [RubyCommand.Argument] = array
.filter { $0?.value != nil }
.compactMap { $0 }
let command = RubyCommand(commandID: "", methodName: "jira_release_notes", className: nil, args: args)
  return runner.executeCommand(command)
}
```