### PR TITLE
Filter on a list of components

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ password | Password for Jira or api token | FL_JIRA_PASSWORD |
 project | Jira project name | FL_JIRA_PROJECT |
 version | Jira project version | FL_JIRA_PROJECT_VERSION |
 status | Jira issue status | FL_JIRA_STATUS |
+components | An array of Jira issue components | FL_JIRA_COMPONENTS |
 format | Format text. Plain, html or none | FL_JIRA_RELEASE_NOTES_FORMAT | plain
 max_results | Maximum number of issues | FL_JIRA_RELEASE_NOTES_MAX_RESULTS | 50
 

--- a/lib/fastlane/plugin/jira_release_notes/actions/jira_release_notes_action.rb
+++ b/lib/fastlane/plugin/jira_release_notes/actions/jira_release_notes_action.rb
@@ -112,7 +112,7 @@ module Fastlane
                                        sensitive: true,
                                        default_value: ""),
           FastlaneCore::ConfigItem.new(key: :components,
-                                       env_name: "FL_JIRA_components",
+                                       env_name: "FL_JIRA_COMPONENTS",
                                        description: "Jira issue components",
                                        type: Array,
                                        sensitive: true,

--- a/lib/fastlane/plugin/jira_release_notes/actions/jira_release_notes_action.rb
+++ b/lib/fastlane/plugin/jira_release_notes/actions/jira_release_notes_action.rb
@@ -16,6 +16,7 @@ module Fastlane
         version = params[:version]
         project = params[:project]
         status = params[:status]
+        components = params[:components]
         max_results = params[:max_results].to_i
         issues = []
 
@@ -33,6 +34,10 @@ module Fastlane
           unless status.nil? or status.empty?
             jql += " AND status = '#{status}'"
           end
+          unless components.nil? or components.empty?
+            jql += " AND component in (#{components.map{|s| "\"#{s}\""}.join(", ")})"
+          end
+          UI.message("jql '#{jql}'")
           issues = client.Issue.jql(jql,max_results: max_results)
 
         rescue JIRA::HTTPError => e
@@ -41,7 +46,7 @@ module Fastlane
           UI.user_error!("#{e} #{fields.join(', ')}")
         end
 
-        UI.success("📝  #{issues.count} issues from JIRA project '#{project}', version '#{version}', status '#{status}'")
+        UI.success("📝  #{issues.count} issues from JIRA project '#{project}', version '#{version}', status '#{status}', components '#{components}'")
 
         case params[:format]
         when "plain"
@@ -104,6 +109,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :status,
                                        env_name: "FL_JIRA_STATUS",
                                        description: "Jira issue status",
+                                       sensitive: true,
+                                       default_value: ""),
+          FastlaneCore::ConfigItem.new(key: :components,
+                                       env_name: "FL_JIRA_components",
+                                       description: "Jira issue components",
+                                       type: Array,
                                        sensitive: true,
                                        default_value: ""),
           FastlaneCore::ConfigItem.new(key: :version,

--- a/spec/jira_release_notes_action_spec.rb
+++ b/spec/jira_release_notes_action_spec.rb
@@ -6,6 +6,7 @@ describe Fastlane::Actions::JiraReleaseNotesAction do
     @project = 'ABC'
     @version = '1.0'
     @status = 'Testable'
+    @components = ["API", "UI"]
   end
 
   describe 'Release Notes' do
@@ -40,6 +41,22 @@ describe Fastlane::Actions::JiraReleaseNotesAction do
         expect(JIRA::Resource::Issue).to receive(:jql) do |client, query|
           expect(client.options).to include(@options)
           expect(query).to eql("PROJECT = '#{@project}' AND fixVersion = '#{@version}' AND status = '#{@status}'")
+        end.and_return(@issues)
+
+        notes = Fastlane::Actions::JiraReleaseNotesAction.run(@params)
+        expect(notes).to eql(@issues)
+      end
+    end
+
+    describe 'Using components' do
+      before(:each) do
+        @params[:components] = @components
+      end
+
+      it 'array components' do
+        expect(JIRA::Resource::Issue).to receive(:jql) do |client, query|
+          expect(client.options).to include(@options)
+          expect(query).to eql("PROJECT = '#{@project}' AND fixVersion = '#{@version}' AND component in (#{@components.map{|s| "\"#{s}\""}.join(", ")})")
         end.and_return(@issues)
 
         notes = Fastlane::Actions::JiraReleaseNotesAction.run(@params)


### PR DESCRIPTION
This PR will add an array of components as input, this is useful if we don't want to include all tickets in the release notes but only tickets related to specific components, that will permit for example to exclude tickets related to CI which are not relevant for final user.

